### PR TITLE
reverse_conn: add flag for reverse conn http filter to immediately send local reply

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -833,6 +833,11 @@ public:
    * @return true if the filter should shed load based on the system pressure, typically memory.
    */
   virtual bool shouldLoadShed() const PURE;
+
+  /**
+   * @return set a flag to send a local reply immediately. Currently only used for reverse connections.
+   */
+  virtual void setForceImmediateLocalReply(bool value) PURE;
 };
 
 /**

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -155,6 +155,11 @@ public:
   const StreamInfo::StreamInfo& streamInfo() const override { return stream_info_; }
   StreamInfo::StreamInfoImpl& streamInfo() override { return stream_info_; }
 
+  void setForceImmediateLocalReply(bool value) override {
+    ENVOY_LOG(error, "Cannot set value {}. AsyncStreamImpl does not support force immediate local reply.",
+              value);
+  }
+
 protected:
   AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
                   const AsyncClient::StreamOptions& options, absl::Status& creation_status);

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -448,6 +448,10 @@ void ActiveStreamDecoderFilter::modifyDecodingBuffer(
   callback(*parent_.buffered_request_data_.get());
 }
 
+void ActiveStreamDecoderFilter::setForceImmediateLocalReply(bool value) {
+  parent_.setForceImmediateLocalReply(value);
+}
+
 void ActiveStreamDecoderFilter::sendLocalReply(
     Code code, absl::string_view body,
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
@@ -1002,10 +1006,15 @@ void DownstreamFilterManager::sendLocalReply(
       // route refreshment in the response filter chain.
       cb->route(nullptr);
     }
-
-    // We only prepare a local reply to execute later if we're actively
-    // invoking filters to avoid re-entrant in filters.
-    if (state_.filter_call_state_ & FilterCallState::IsDecodingMask) {
+    // We only prepare a local reply to execute later if we're actively invoking filters to avoid
+    // re-entrant in filters.
+    //
+    // For reverse connections (where upstream initiates the connection to downstream), we need to
+    // send local replies immediately rather than queuing them. This ensures proper handling of the
+    // reversed connection flow and prevents potential issues with connection state and filter chain
+    // processing.
+    if (!force_immediate_local_reply_ &&
+        (state_.filter_call_state_ & FilterCallState::IsDecodingMask)) {
       prepareLocalReplyViaFilterChain(is_grpc_request, code, body, modify_headers, is_head_request,
                                       grpc_status, details);
     } else {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -324,6 +324,8 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
   void stopDecodingIfNonTerminalFilterEncodedEndStream(bool encoded_end_stream);
   StreamDecoderFilters::Iterator entry() const { return entry_; }
 
+  void setForceImmediateLocalReply(bool value) override;
+
   StreamDecoderFilterSharedPtr handle_;
   StreamDecoderFilters::Iterator entry_{};
   bool is_grpc_request_{};
@@ -911,6 +913,7 @@ public:
   bool sawDownstreamReset() { return state_.saw_downstream_reset_; }
 
   virtual bool shouldLoadShed() { return false; };
+  void setForceImmediateLocalReply(bool value) { force_immediate_local_reply_ = value; }
 
   void sendGoAwayAndClose() {
     // Stop filter chain iteration by checking encoder or decoder chain.
@@ -1108,6 +1111,7 @@ private:
   const uint64_t stream_id_;
   Buffer::BufferMemoryAccountSharedPtr account_;
   const bool proxy_100_continue_;
+  bool force_immediate_local_reply_{false};
 
   StreamDecoderFilters decoder_filters_;
   StreamEncoderFilters encoder_filters_;

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -241,6 +241,8 @@ public:
   const LowerCaseString XContentTypeOptions{"x-content-type-options"};
   const LowerCaseString XSquashDebug{"x-squash-debug"};
   const LowerCaseString EarlyData{"early-data"};
+  const LowerCaseString EnvoyDstNodeUUID{"x-remote-node-id"};
+  const LowerCaseString EnvoyDstClusterUUID{"x-dst-cluster-uuid"};
 
   struct {
     const std::string Close{"close"};

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -582,6 +582,8 @@ public:
       os << spaces << "TcpProxy " << this << DUMP_MEMBER(streamId()) << "\n";
       DUMP_DETAILS(parent_->getStreamInfo().upstreamInfo());
     }
+
+    void setForceImmediateLocalReply(bool) override {}
     Filter* parent_{};
     Http::RequestTrailerMapPtr request_trailer_map_;
     std::shared_ptr<Http::NullRouteImpl> route_;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -341,6 +341,7 @@ public:
   MOCK_METHOD(absl::optional<Upstream::LoadBalancerContext::OverrideHost>, upstreamOverrideHost, (),
               (const));
   MOCK_METHOD(bool, shouldLoadShed, (), (const));
+  MOCK_METHOD(void, setForceImmediateLocalReply, (bool));
 
   Buffer::InstancePtr buffer_;
   std::list<DownstreamWatermarkCallbacks*> callbacks_{};


### PR DESCRIPTION

Commit Message: reverse_conn: add flag for reverse conn http filter to immediately send local reply
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
